### PR TITLE
Replace www.privacytools.io with privacyguides.org

### DIFF
--- a/_data/wickrme_card.html
+++ b/_data/wickrme_card.html
@@ -10,7 +10,7 @@ Cons:
 <li>Doesn't have as many features as other apps</li>
 <li>Video chat is not available in the personal free version</li>
 <li>The 6 day maximum retention period for messages may be too short if you like to be able to go back to old messages</li>
-<li>Based in the USA, if you are worried about using something from a <a href="https://www.privacytools.io/#ukusa" target="_blank">5 eyes country</a></li>
+<li>Based in the USA, if you are worried about using something from a <a href="https://privacyguides.org/providers/#ukusa" target="_blank">5 eyes country</a></li>
 	<li>No web app. You must install the desktop application on work or public computers to chat. This may be an issue if you do not have permissions to install the application.</li>
 </ul>
 Other features:

--- a/_includes/install_wickrme_row.md
+++ b/_includes/install_wickrme_row.md
@@ -9,7 +9,7 @@
   <li>Doesn't have as many features as other apps</li>
   <li>Video chat is not available in the personal free version</li>
   <li>The 6 day maximum retention period for messages may be too short if you like to be able to go back to old messages</li>
-  <li>Based in the USA, if you are worried about using something from a <a href="https://www.privacytools.io/#ukusa" target="_blank">5 eyes country</a></li>
+  <li>Based in the USA, if you are worried about using something from a <a href="https://privacyguides.org/providers/#ukusa" target="_blank">5 eyes country</a></li>
     <li>No web app. You must install the desktop application on work or public computers to chat. This may be an issue if you do not have permissions to install the application.</li>
   </ul>
   Other features:

--- a/otherwebsites.md
+++ b/otherwebsites.md
@@ -28,7 +28,7 @@ Here are some other resources that contain information about online privacy:<br>
 
 <h2>Websites</h2>
 <br>
-<a href="https://www.privacytools.io/#im" target="_blank">privacytools.io</a><br>
+<a href="https://privacyguides.org/software/real-time-communication/#im" target="_blank">privacyguides.org</a><br>
 <a href="https://prism-break.org" target="_blank">Prism Break</a><br>
 <a href="https://ssd.eff.org/en/module/communicating-others" target="_blank">EFF- Communication with Others</a> (Also <a href="https://www.eff.org/secure-messaging-scorecard" target="_blank">EFF messaging scorecard</a> is out of date but still useful)<br>
 <a href="https://ssd.eff.org" target="_blank">EFF Surveillence Self-Defense</a><br>


### PR DESCRIPTION
from https://github.com/privacytools/privacytools.io
> This project is archived. See our [Welcome to Privacy Guides](https://privacyguides.org/blog/2021/09/14/welcome-to-privacy-guides/) post for more information. Our project has now moved on to [Privacy Guides](https://privacyguides.org).

and from https://privacyguides.org
> The former PrivacyTools team is now working on **Privacy Guides**, your trusted resource for crowdsourced software recommendations. Read the [history of this decision](https://nitter.net/privacy_guides/status/1443633412800225280#m) on Twitter, and the [original announcement](https://teddit.net/r/PrivacyGuides/comments/pnh9n8/what_happened_to_privacytools/) and [FAQ](https://teddit.net/r/PrivacyGuides/comments/pnhn4a/rprivacyguides_privacyguidesorg_what_you_need_to/) on Reddit! 